### PR TITLE
Backend(Workers): Add network worker logic

### DIFF
--- a/packages/backend/src/models/Blockchains.js
+++ b/packages/backend/src/models/Blockchains.js
@@ -2,6 +2,7 @@ import { Schema, model } from "mongoose";
 
 const chainSchema = new Schema(
   {
+    _id: String,
     networkID: String,
     ticker: String,
     name: String,

--- a/packages/backend/src/models/NetworkData.js
+++ b/packages/backend/src/models/NetworkData.js
@@ -3,8 +3,8 @@ import { Schema, model } from "mongoose";
 const networkDataSchema = new Schema(
   {
     nodesStaked: Number,
-    AppsStaked: Number,
-    poktStaked: Number,
+    appsStaked: Number,
+    poktStaked: String,
     createdAt: Date,
   },
   { collection: "NetworkData" }

--- a/packages/backend/src/workers/application.js
+++ b/packages/backend/src/workers/application.js
@@ -3,7 +3,7 @@ import { CHAINS } from "workers/utils";
 
 // TODO: Add Sentry, logger
 
-async function createApplicationAndFund() {
+async function createApplicationAndFund(chain) {
   // TODO: Create application credentials
   // TODO: Create application in DB
   // TODO: Send funds from Main account to App

--- a/packages/backend/src/workers/config.js
+++ b/packages/backend/src/workers/config.js
@@ -3,12 +3,7 @@ import {
   stakeAppPool,
   unstakeAvailableApps,
 } from "workers/application";
-import {
-  getTotalNodeCount,
-  getTotalAppCount,
-  getTotalPoktStaked,
-  getNodeCountForChains,
-} from "workers/network";
+import { getNetworkStatsCount, getNodeCountForChains } from "workers/network";
 import {
   ONE_MINUTES,
   FIVE_MINUTES,
@@ -44,21 +39,9 @@ export const WORKERS = [
     recurrence: FIFTEEN_MINUTES,
   },
   {
-    name: "Global node counter",
+    name: "Network stats counter",
     color: "yellow",
-    workerFn: getTotalNodeCount,
-    recurrence: SIXTY_MINUTES,
-  },
-  {
-    name: "Global app counter",
-    color: "yellow",
-    workerFn: getTotalAppCount,
-    recurrence: SIXTY_MINUTES,
-  },
-  {
-    name: "Global pokt staked counter",
-    color: "yellow",
-    workerFn: getTotalPoktStaked,
+    workerFn: getNetworkStatsCount,
     recurrence: SIXTY_MINUTES,
   },
   {

--- a/packages/backend/src/workers/config.js
+++ b/packages/backend/src/workers/config.js
@@ -7,7 +7,7 @@ import {
   getTotalNodeCount,
   getTotalAppCount,
   getTotalPoktStaked,
-  getTotalNodeCountForChains,
+  getNodeCountForChains,
 } from "workers/network";
 import {
   ONE_MINUTES,
@@ -64,7 +64,7 @@ export const WORKERS = [
   {
     name: "Nodes per chain counter",
     color: "yellow",
-    workerFn: getTotalNodeCountForChains,
+    workerFn: getNodeCountForChains,
     recurrence: SIXTY_MINUTES,
   },
 ];

--- a/packages/backend/src/workers/network.js
+++ b/packages/backend/src/workers/network.js
@@ -235,13 +235,21 @@ async function getApplications(status) {
 }
 
 async function getTotalNodesStaked() {
-  const stakedNodes = (await getNodes(StakingStatus.Staked)) ?? [];
+  const stakedNodes = await getNodes(StakingStatus.Staked);
+
+  if (!stakedNodes || stakedNodes?.length === 0) {
+    throw new Error("PocketJS failed to retrieve staked nodes");
+  }
 
   return stakedNodes.length;
 }
 
 async function getTotalAppsStaked() {
-  const stakedApps = (await getApplications(StakingStatus.Staked)) ?? [];
+  const stakedApps = await getApplications(StakingStatus.Staked);
+
+  if (!stakedApps || stakedApps?.length === 0) {
+    throw new Error("PocketJS failed to retrieve staked apps");
+  }
 
   return stakedApps.length;
 }

--- a/packages/backend/src/workers/network.js
+++ b/packages/backend/src/workers/network.js
@@ -1,9 +1,252 @@
-async function getNodeCount(chain) {}
+/* global BigInt */
+import {
+  Account,
+  Application,
+  ApplicationParams,
+  Configuration,
+  HttpRpcProvider,
+  Node,
+  NodeParams,
+  Pocket,
+  PocketRpcProvider,
+  RpcError,
+  StakingStatus,
+  Transaction,
+  typeGuard,
+  UnlockedAccount,
+  PocketAAT,
+} from "@pokt-network/pocket-js";
+import NetworkData from "models/NetworkData";
+import Blockchains from "models/Blockchains";
+import env from "environment";
 
-export async function getTotalNodeCount() {}
+function getPocketDispatchers() {
+  const dispatchersStr = POCKET_NETWORK_CONFIGURATION.dispatchers;
 
-export async function getTotalAppCount() {}
+  if (dispatchersStr === "") {
+    return [];
+  }
 
-export async function getTotalPoktStaked() {}
+  return dispatchersStr.split(",").map(function (dispatcherURLStr) {
+    return new URL(dispatcherURLStr);
+  });
+}
 
-export async function getNodeCountForChains() {}
+const POCKET_NETWORK_CONFIGURATION = env("pocket_network");
+
+const POCKET_CONFIGURATION = new Configuration(
+  POCKET_NETWORK_CONFIGURATION.max_dispatchers,
+  POCKET_NETWORK_CONFIGURATION.max_sessions,
+  0,
+  POCKET_NETWORK_CONFIGURATION.request_timeout,
+  undefined,
+  undefined,
+  POCKET_NETWORK_CONFIGURATION.block_time,
+  undefined,
+  undefined,
+  POCKET_NETWORK_CONFIGURATION.reject_self_signed_certificates
+);
+
+const pocketInstance = new Pocket(
+  getPocketDispatchers(),
+  undefined,
+  POCKET_CONFIGURATION
+);
+
+/**
+ * @returns {HttpRpcProvider} HTTP RPC Provider.
+ */
+function getHttpRPCProvider() {
+  const httpProviderNode = POCKET_NETWORK_CONFIGURATION.http_provider_node;
+
+  if (!httpProviderNode || httpProviderNode === "") {
+    throw new Error("Invalid HTTP Provider Node: " + httpProviderNode);
+  }
+  return new HttpRpcProvider(new URL(httpProviderNode));
+}
+
+/**
+ * @returns {HttpRpcProvider | PocketRpcProvider} RPC Provider.
+ */
+async function getRPCProvider() {
+  const providerType = POCKET_NETWORK_CONFIGURATION.provider_type;
+
+  if (providerType.toLowerCase() === "http") {
+    return getHttpRPCProvider();
+  } else if (providerType.toLowerCase() === "pocket") {
+    return await getPocketRPCProvider();
+  } else {
+    // Default to HTTP RPC Provider
+    return getHttpRPCProvider();
+  }
+}
+
+/**
+ * Get Nodes data.
+ *
+ * @param {number} status Status of the nodes to retrieve.
+ *
+ * @returns {Promise<Node[]>} The nodes data.
+ * @async
+ */
+async function getNodes(status) {
+  let page = 1;
+  let nodeList = [];
+
+  const perPage = 100;
+  const pocketRpcProvider = await getRPCProvider();
+  const nodesResponse = await pocketInstance
+    .rpc(pocketRpcProvider)
+    .query.getNodes(status, undefined, BigInt(0), undefined, page, perPage);
+
+  if (nodesResponse instanceof RpcError) {
+    return [];
+  }
+
+  const totalPages = nodesResponse.totalPages;
+
+  nodesResponse.nodes.forEach((node) => {
+    nodeList.push(node);
+  });
+
+  page++;
+
+  while (page <= totalPages) {
+    const response = await pocketInstance
+      .rpc(pocketRpcProvider)
+      .query.getNodes(status, undefined, BigInt(0), undefined, page, perPage);
+
+    // Increment page variable
+    page++;
+
+    if (response instanceof RpcError) {
+      page = totalPages;
+      return;
+    }
+
+    response.nodes.forEach((node) => {
+      nodeList.push(node);
+    });
+  }
+
+  return nodesResponse.nodes;
+}
+
+/**
+ * Get Applications data.
+ *
+ * @param {number} status Status of the apps to retrieve.
+ *
+ * @returns {Promise<Application[]>} The applications data.
+ * @async
+ */
+async function getApplications(status) {
+  let page = 1;
+  let applicationList = [];
+
+  const pocketRpcProvider = await getRPCProvider();
+  const perPage = 100;
+  const applicationsResponse = await pocketInstance
+    .rpc(pocketRpcProvider)
+    .query.getApps(status, BigInt(0), undefined, page, perPage);
+
+  // Check for RpcError
+  if (applicationsResponse instanceof RpcError) {
+    return [];
+  }
+
+  // Retrieve the total pages count
+  const totalPages = applicationsResponse.totalPages;
+
+  // Retrieve the app list
+  while (page <= totalPages) {
+    const response = await pocketInstance
+      .rpc(pocketRpcProvider)
+      .query.getApps(status, BigInt(0), undefined, page, perPage);
+
+    // Increment page variable
+    page++;
+
+    // Check for error
+    if (response instanceof RpcError) {
+      page = totalPages;
+      return;
+    }
+    // Add the result to the application list
+    response.applications.forEach((app) => {
+      applicationList.push(app);
+    });
+  }
+
+  return applicationList;
+}
+
+async function getTotalNodesStaked() {
+  const stakedNodes = (await getNodes(StakingStatus.Staked)) ?? [];
+  return stakedNodes.length;
+}
+
+async function getTotalAppsStaked() {
+  const stakedApps = (await getApplications(StakingStatus.Staked)) ?? [];
+  return stakedApps.length;
+}
+
+async function getTotalPoktStaked() {
+  const stakedNodes = await getNodes(StakingStatus.Staked);
+  const stakedApps = await getApplications(StakingStatus.Staked);
+
+  const totalNodePoktStaked = stakedNodes.reduce(
+    (prev, cur) => prev + cur.stakedTokens,
+    0n
+  );
+  const totalAppPoktStaked = stakedApps.reduce(
+    (prev, cur) => prev + cur.stakedTokens,
+    0n
+  );
+
+  return BigInt(totalNodePoktStaked + totalAppPoktStaked);
+}
+
+export async function getNetworkStatsCount() {
+  const totalNodesStaked = await getTotalNodesStaked();
+  const totalAppsStaked = await getTotalAppsStaked();
+  const totalPoktStaked = await getTotalPoktStaked();
+
+  const networkStats = new NetworkData({
+    nodesStaked: totalNodesStaked,
+    appsStaked: totalAppsStaked,
+    poktStaked: totalPoktStaked.toString(),
+    createdAt: new Date(Date.now()),
+  });
+  await networkStats.save();
+}
+
+export async function getNodeCountForChains() {
+  const chainNodeCounter = new Map();
+  const stakedNodes = await getNodes(StakingStatus.Staked);
+
+  if (!stakedNodes) {
+    throw new Error("pocketJS failed when fetching nodes");
+  }
+
+  for (const { chains } of stakedNodes) {
+    for (const chainId of chains) {
+      if (!chainNodeCounter.has(chainId)) {
+        chainNodeCounter.set(chainId, 0);
+      } else {
+        const currentCount = Number(chainNodeCounter.get(chainId));
+        chainNodeCounter.set(chainId, currentCount + 1);
+      }
+    }
+  }
+
+  chainNodeCounter.forEach(async function updateChainCount(count, id) {
+    const blockchain = await Blockchains.findById(id);
+    if (!blockchain) {
+      // TODO: Add logger through dep injection to signal a non-registered chain
+      return;
+    }
+    blockchain.nodeCount = count;
+    await blockchain.save();
+  });
+}

--- a/packages/backend/src/workers/network.js
+++ b/packages/backend/src/workers/network.js
@@ -312,6 +312,7 @@ export async function getNodeCountForChains() {
       // TODO: Add logger through dep injection to signal a non-registered chain
       return;
     }
+
     blockchain.nodeCount = count;
     await blockchain.save();
   });


### PR DESCRIPTION
Adds the necessary code for the network worker to code. The finalized, active workers will be:

- `Network stats counter`: registers the nodes, apps, and total pocket staked.
- `Nodes per chain counter`: Updates the node count per chain.

There will be the need for a refactor of the `pocketJS` logic to avoid coupling, and also there will be upcoming changes due to using dependency injection so that all workers can access a context, mainly for having access to the logger.