### PR TITLE
Backend(workers): add dependency injection

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "build": "babel ./src --out-dir ./dist --source-maps --copy-files",
-    "start": "nodemon --ignore ./dist --exec babel-node ./src/index.js",
+    "start": "NODE_ENV=development nodemon --ignore ./dist --exec babel-node ./src/index.js",
     "test": "mocha test",
     "test:services": "mocha test/services",
     "test:providers": "mocha test/providers",
@@ -25,9 +25,7 @@
   "mocha": {
     "exit": true,
     "require": "@babel/register",
-    "file": [
-      "test/setupTests.js"
-    ]
+    "file": ["test/setupTests.js"]
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",

--- a/packages/backend/src/workers/config.js
+++ b/packages/backend/src/workers/config.js
@@ -23,31 +23,31 @@ export const WORKERS = [
   {
     name: "App pool filler",
     color: "green",
-    workerFn: fillAppPool,
+    workerFn: (ctx) => fillAppPool(ctx),
     recurrence: ONE_MINUTES,
   },
   {
     name: "App pool staker",
     color: "green",
-    workerFn: stakeAppPool,
+    workerFn: (ctx) => stakeAppPool(ctx),
     recurrence: FIVE_MINUTES,
   },
   {
     name: "App decomissioner",
     color: "green",
-    workerFn: unstakeAvailableApps,
+    workerFn: (ctx) => unstakeAvailableApps(ctx),
     recurrence: FIFTEEN_MINUTES,
   },
   {
     name: "Network stats counter",
     color: "yellow",
-    workerFn: getNetworkStatsCount,
+    workerFn: (ctx) => getNetworkStatsCount(ctx),
     recurrence: SIXTY_MINUTES,
   },
   {
     name: "Nodes per chain counter",
     color: "yellow",
-    workerFn: getNodeCountForChains,
+    workerFn: (ctx) => getNodeCountForChains(ctx),
     recurrence: SIXTY_MINUTES,
   },
 ];

--- a/packages/backend/src/workers/index.js
+++ b/packages/backend/src/workers/index.js
@@ -18,7 +18,7 @@ export function startWorkers() {
         `Starting worker "${name}" at ${startInUtc} with color ${color}`
       );
       try {
-        await workerFn();
+        await workerFn({ logger });
 
         endTime = Date.now();
         const endInUtc = new Date(endTime).toUTCString();

--- a/packages/backend/src/workers/network.js
+++ b/packages/backend/src/workers/network.js
@@ -270,7 +270,7 @@ async function getTotalPoktStaked() {
   return BigInt(totalNodePoktStaked + totalAppPoktStaked);
 }
 
-export async function getNetworkStatsCount() {
+export async function getNetworkStatsCount(ctx) {
   const totalNodesStaked = await getTotalNodesStaked();
   const totalAppsStaked = await getTotalAppsStaked();
   const totalPoktStaked = await getTotalPoktStaked();
@@ -285,7 +285,7 @@ export async function getNetworkStatsCount() {
   await networkStats.save();
 }
 
-export async function getNodeCountForChains() {
+export async function getNodeCountForChains(ctx) {
   const chainNodeCounter = new Map();
   const stakedNodes = await getNodes(StakingStatus.Staked);
 
@@ -309,7 +309,9 @@ export async function getNodeCountForChains() {
     const blockchain = await Blockchains.findById(id);
 
     if (!blockchain) {
-      // TODO: Add logger through dep injection to signal a non-registered chain
+      ctx.logger.warn(
+        `NOTICE: chain ${id} not detected, count of nodes is ${count}`
+      );
       return;
     }
 


### PR DESCRIPTION
Adds very a simple way to inject dependencies to workers—just a high order function that can receive and pass additional parameters. Also adds the NODE_ENV flag on boot when using the `start` script for dev.