### PR TITLE
Frontend(UI): Clamp graphs / thresholds to POKT staked, misc UI fixes

### DIFF
--- a/packages/frontend/src/components/AppStatus/AppStatus.js
+++ b/packages/frontend/src/components/AppStatus/AppStatus.js
@@ -3,10 +3,11 @@ import TokenAmount from "token-amount";
 import "styled-components/macro";
 import Box from "components/Box/Box";
 import { Spacer, Tag, textStyle, GU } from "ui";
-import { getStakingStatus } from "lib/pocket-utils";
+import { getStakingStatus, getThresholdsPerStake } from "lib/pocket-utils";
 
 export default function AppStatus({ appOnChainStatus }) {
   const { status, staked_tokens: stakedTokens } = appOnChainStatus;
+  const { legibleMaxRelays } = getThresholdsPerStake(stakedTokens);
 
   const stakingStatus = useMemo(() => getStakingStatus(status), [status]);
 
@@ -49,7 +50,7 @@ export default function AppStatus({ appOnChainStatus }) {
         </li>
         <Spacer size={2 * GU} />
         <li>
-          Max relays per day: <span>1M</span>
+          Max relays per day: <span>{legibleMaxRelays}</span>
         </li>
       </ul>
     </Box>

--- a/packages/frontend/src/lib/pocket-utils.js
+++ b/packages/frontend/src/lib/pocket-utils.js
@@ -10,6 +10,36 @@ const STAKING_STATUSES_LABELS = {
   2: "Staked",
 };
 
+const ONE_MILLION_RELAYS_STAKE = 24950100000;
+const ONE_HUNDRED_THOUSAND_RELAYS_STAKE = 2495010000;
+
+const THRESHOLDS_PER_STAKE = new Map([
+  [
+    ONE_MILLION_RELAYS_STAKE,
+    {
+      maxRelays: 1000000,
+      graphThreshold: 1500000,
+      legibleMaxRelays: "1M",
+    },
+  ],
+  [
+    ONE_HUNDRED_THOUSAND_RELAYS_STAKE,
+    {
+      maxRelays: 100000,
+      graphThreshold: 150000,
+      legibleMaxRelays: "1M",
+    },
+  ],
+]);
+
 export function getStakingStatus(status) {
   return STAKING_STATUSES_LABELS[status];
+}
+
+export function getThresholdsPerStake(stake) {
+  if (!THRESHOLDS_PER_STAKE.has(stake)) {
+    throw new Error("Unknown stake");
+  }
+
+  return THRESHOLDS_PER_STAKE.get(stake);
 }

--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
@@ -25,6 +25,7 @@ import FloatUp from "components/FloatUp/FloatUp";
 import SuccessIndicator from "views/Dashboard/ApplicationDetail/SuccessIndicator";
 import { prefixFromChainId } from "lib/chain-utils";
 import { norm } from "lib/math-utils";
+import { getThresholdsPerStake } from "lib/pocket-utils";
 
 const ONE_MILLION = 1000000;
 
@@ -78,11 +79,13 @@ export default function AppInfo({
       : previousSuccessfulRelays.successfulWeeklyRelays /
           previousSuccessfulRelays.previousTotalRelays;
   }, [previousSuccessfulRelays]);
-
   const { labels: usageLabels = [], lines: usageLines = [] } = useMemo(
     () => formatDailyRelaysForGraphing(dailyRelayData),
     [dailyRelayData]
   );
+
+  const { staked_tokens: stakedTokens } = appOnChainData;
+  const { graphThreshold } = getThresholdsPerStake(stakedTokens);
 
   return (
     <FloatUp
@@ -114,6 +117,7 @@ export default function AppInfo({
                 chartLabels={usageLabels}
                 chartLines={usageLines}
                 sessionRelays={currentSessionRelays}
+                threshold={graphThreshold}
               />
               <Spacer size={2 * GU} />
               <LatestRequests latestRequests={latestRelaysData.latestRelays} />
@@ -339,7 +343,7 @@ function AvgLatency({ avgLatency }) {
   );
 }
 
-function UsageTrends({ chartLabels, chartLines, sessionRelays }) {
+function UsageTrends({ chartLabels, chartLines, sessionRelays, threshold }) {
   const isChartLinesEmpty = useMemo(() => chartLines[0].values.length === 0, [
     chartLines,
   ]);

--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
@@ -169,12 +169,7 @@ function EndpointDetails({ chainId, appId }) {
   );
 }
 
-function SuccessRate({
-  appId,
-  previousSuccessRate = 0,
-  successRate,
-  totalRequests,
-}) {
+function SuccessRate({ previousSuccessRate = 0, successRate, totalRequests }) {
   const history = useHistory();
   const { url } = useRouteMatch();
   const numberProps = useSpring({
@@ -263,7 +258,7 @@ function SuccessRate({
                 align-items: center;
               `}
             >
-              <SuccessIndicator mode={mode} />
+              {totalRequests ? <SuccessIndicator mode={mode} /> : ""}
               <Spacer size={GU / 2} />
               <span>{Math.abs(successRateDelta)}%</span>
             </div>

--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/ApplicationDetail.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/ApplicationDetail.js
@@ -137,7 +137,11 @@ export default function ApplicationDetail() {
         />
       </Route>
       <Route path={`${path}/notifications`}>
-        <Notifications appData={appData} dailyRelayData={dailyRelayCountData} />
+        <Notifications
+          appData={appData}
+          appOnChainData={appOnChainData}
+          dailyRelayData={dailyRelayCountData}
+        />
       </Route>
       <Route path={`${path}/chains`}>
         <Chains appData={appData} />

--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/Notifications.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/Notifications.js
@@ -16,6 +16,7 @@ import {
 } from "ui";
 import Box from "components/Box/Box";
 import FloatUp from "components/FloatUp/FloatUp";
+import { getThresholdsPerStake } from "lib/pocket-utils";
 import env from "environment";
 
 const MAX_RELAYS = 1000000;
@@ -27,7 +28,11 @@ const DEFAULT_PERCENTAGES = {
   full: false,
 };
 
-export default function Notifications({ appData, dailyRelayData }) {
+export default function Notifications({
+  appData,
+  appOnChainData,
+  dailyRelayData,
+}) {
   const [chosenPercentages, setChosenPercentages] = useState(
     appData?.notificationSettings ?? DEFAULT_PERCENTAGES
   );
@@ -111,6 +116,9 @@ export default function Notifications({ appData, dailyRelayData }) {
     [hasChanged, isNotificationsLoading]
   );
 
+  const { staked_tokens: stakedTokens } = appOnChainData;
+  const { legibleMaxRelays } = getThresholdsPerStake(stakedTokens);
+
   return (
     <FloatUp
       loading={false}
@@ -151,7 +159,7 @@ export default function Notifications({ appData, dailyRelayData }) {
                     Daily bandwith usage
                   </h2>
                   {compactMode && <Spacer size={1 * GU} />}
-                  <h3>Max relays per day: 1M</h3>
+                  <h3>Max relays per day: {legibleMaxRelays}</h3>
                 </div>
                 <Spacer size={2 * GU} />
                 <Inline>
@@ -283,24 +291,28 @@ export default function Notifications({ appData, dailyRelayData }) {
                 level="quarter"
                 checked={chosenPercentages.quarter}
                 onChange={() => onChosePercentageChange("quarter")}
+                maxRelays={legibleMaxRelays}
               />
               <Spacer size={2 * GU} />
               <NotificationPreference
                 level="half"
                 checked={chosenPercentages.half}
                 onChange={() => onChosePercentageChange("half")}
+                maxRelays={legibleMaxRelays}
               />
               <Spacer size={2 * GU} />
               <NotificationPreference
                 level="threeQuarters"
                 checked={chosenPercentages.threeQuarters}
                 onChange={() => onChosePercentageChange("threeQuarters")}
+                maxRelays={legibleMaxRelays}
               />
               <Spacer size={2 * GU} />
               <NotificationPreference
                 level="full"
                 checked={chosenPercentages.full}
                 onChange={() => onChosePercentageChange("full")}
+                maxRelays={legibleMaxRelays}
               />
             </>
           }
@@ -310,7 +322,7 @@ export default function Notifications({ appData, dailyRelayData }) {
   );
 }
 
-function NotificationPreference({ level, checked, onChange }) {
+function NotificationPreference({ level, checked, onChange, maxRelays }) {
   const theme = useTheme();
 
   const backgroundColor = useMemo(() => {
@@ -368,7 +380,7 @@ function NotificationPreference({ level, checked, onChange }) {
               ${textStyle("body3")}
             `}
           >
-            of 1M relays
+            of {maxRelays} relays
           </span>
         </h3>
         <Switch checked={checked} onChange={onChange} />

--- a/packages/frontend/src/views/Dashboard/Network/NetworkInfo.js
+++ b/packages/frontend/src/views/Dashboard/Network/NetworkInfo.js
@@ -2,25 +2,10 @@ import React from "react";
 import TokenAmount from "token-amount";
 import { useViewport } from "use-viewport";
 import "styled-components/macro";
-import {
-  LoadingRing,
-  Spacer,
-  Split,
-  Table,
-  TableCell,
-  TableHeader,
-  TableRow,
-  GU,
-} from "ui";
+import { Spacer, Split, Table, TableCell, TableHeader, TableRow, GU } from "ui";
 import Box from "components/Box/Box";
-import {
-  useNetworkSummary,
-  useChains,
-} from "views/Dashboard/Network/network-hooks";
 
-export default function RelayInfo() {
-  const { isSummaryLoading, summaryData } = useNetworkSummary();
-  const { isChainsLoading, chains } = useChains();
+export default function RelayInfo({ chains, summaryData }) {
   const { within } = useViewport();
   const compactMode = within(-1, "medium");
 
@@ -37,84 +22,76 @@ export default function RelayInfo() {
             `}
           `}
         >
-          {isChainsLoading ? (
-            <LoadingRing mode="half-circle" />
-          ) : (
-            <Table
-              noSideBorders
-              noTopBorders
-              css={`
-                background: transparent;
-              `}
-              header={
-                <>
-                  <TableRow>
-                    <TableHeader title="Network" />
-                    <TableHeader title="Network ID" />
-                    <TableHeader title="Ticker" />
-                    <TableHeader title="Node count" />
-                  </TableRow>
-                </>
-              }
-            >
-              {chains.map(
-                ({
-                  id,
-                  description,
-                  ticker,
-                  network,
-                  nodeCount,
-                  isAvailableForStaking,
-                }) => (
-                  <TableRow key={id}>
-                    <TableCell>
-                      <p>{description || network}</p>
-                    </TableCell>
-                    <TableCell>
-                      <p>{id}</p>
-                    </TableCell>
-                    <TableCell>
-                      <p>{ticker}</p>
-                    </TableCell>
-                    <TableCell>
-                      <p>{nodeCount}</p>
-                    </TableCell>
-                  </TableRow>
-                )
-              )}
-            </Table>
-          )}
+          <Table
+            noSideBorders
+            noTopBorders
+            css={`
+              background: transparent;
+            `}
+            header={
+              <>
+                <TableRow>
+                  <TableHeader title="Network" />
+                  <TableHeader title="Network ID" />
+                  <TableHeader title="Ticker" />
+                  <TableHeader title="Node count" />
+                </TableRow>
+              </>
+            }
+          >
+            {chains.map(
+              ({
+                id,
+                description,
+                ticker,
+                network,
+                nodeCount,
+                isAvailableForStaking,
+              }) => (
+                <TableRow key={id}>
+                  <TableCell>
+                    <p>{description || network}</p>
+                  </TableCell>
+                  <TableCell>
+                    <p>{id}</p>
+                  </TableCell>
+                  <TableCell>
+                    <p>{ticker}</p>
+                  </TableCell>
+                  <TableCell>
+                    <p>{nodeCount}</p>
+                  </TableCell>
+                </TableRow>
+              )
+            )}
+          </Table>
         </Box>
       }
       secondary={
         <Box title="Network stats">
-          {isSummaryLoading ? (
-            <LoadingRing mode="half-circle" />
-          ) : (
-            <ul
-              css={`
-                list-style: none;
-                height: 100%;
-                li {
-                  display: flex;
-                  justify-content: space-between;
-                }
-              `}
-            >
-              <li>
-                Total apps staked: <span>{summaryData.appsStaked} </span>
-              </li>
-              <Spacer size={2 * GU} />
-              <li>
-                Total nodes staked: <span>{summaryData.nodesStaked}</span>
-              </li>
-              <Spacer size={2 * GU} />
-              <li>
-                Total POKT staked:{" "}
-                <span>{TokenAmount.format(summaryData.poktStaked, 6)}</span>
-              </li>
-            </ul>
-          )}
+          <ul
+            css={`
+              list-style: none;
+              height: 100%;
+              li {
+                display: flex;
+                justify-content: space-between;
+              }
+            `}
+          >
+            <li>
+              Total apps staked: <span>{summaryData.appsStaked} </span>
+            </li>
+            <Spacer size={2 * GU} />
+            <li>
+              Total nodes staked: <span>{summaryData.nodesStaked}</span>
+            </li>
+            <Spacer size={2 * GU} />
+            <li>
+              Total POKT staked:{" "}
+              <span>{TokenAmount.format(summaryData.poktStaked, 6)}</span>
+            </li>
+          </ul>
         </Box>
       }
       invert="horizontal"

--- a/packages/frontend/src/views/Dashboard/Network/NetworkStatus.js
+++ b/packages/frontend/src/views/Dashboard/Network/NetworkStatus.js
@@ -8,6 +8,8 @@ import NetworkInfo from "views/Dashboard/Network/NetworkInfo";
 import {
   useNetworkSuccessRate,
   useTotalWeeklyRelays,
+  useNetworkSummary,
+  useChains,
 } from "views/Dashboard/Network/network-hooks";
 import { norm } from "lib/math-utils";
 
@@ -41,6 +43,8 @@ function formatDailyRelaysForGraphing(dailyRelays) {
 export default function NetworkStatus() {
   const { isRelaysError, isRelaysLoading, relayData } = useTotalWeeklyRelays();
   const { isSuccessRateLoading, successRateData } = useNetworkSuccessRate();
+  const { isSummaryLoading, summaryData } = useNetworkSummary();
+  const { isChainsLoading, chains } = useChains();
 
   const { labels = [], lines = [] } = useMemo(
     () =>
@@ -50,10 +54,14 @@ export default function NetworkStatus() {
     [isRelaysError, isRelaysLoading, relayData]
   );
 
-  const loading = useMemo(() => isSuccessRateLoading || isRelaysLoading, [
-    isSuccessRateLoading,
-    isRelaysLoading,
-  ]);
+  const loading = useMemo(
+    () =>
+      isSuccessRateLoading ||
+      isRelaysLoading ||
+      isSummaryLoading ||
+      isChainsLoading,
+    [isChainsLoading, isRelaysLoading, isSuccessRateLoading, isSummaryLoading]
+  );
 
   return (
     <FloatUp
@@ -90,7 +98,7 @@ export default function NetworkStatus() {
             chartLabels={labels}
           />
           <Spacer size={2 * GU} />
-          <NetworkInfo />
+          <NetworkInfo summaryData={summaryData} chains={chains} />
         </>
       )}
     />


### PR DESCRIPTION
The biggest improvement here is the fact that we now have a central source of getting the "clamped" values depending on the stake. Eventually this should be a bit more fluid, but it's good for now—we can just update this as we adjust stake values depending on the chain.