### PR TITLE
chore: re-enable workers

### DIFF
--- a/packages/backend/src/environment.js
+++ b/packages/backend/src/environment.js
@@ -12,7 +12,7 @@ export const ENV_VARS = {
     return process.env.ALLOWED_DOMAINS?.split(",") ?? ["http://localhost:3000"];
   },
   enable_workers() {
-    return false; //Boolean(process.env.ENABLE_WORKERS) || false;
+    return Boolean(process.env.ENABLE_WORKERS) || false;
   },
   HASURA_SECRET() {
     return process.env.HASURA_ADMIN_SECRET || "";


### PR DESCRIPTION
** CHECK BEFORE MERGING **

- [x] Backend has been re-deployed with workers disabled. #99 
- [x] Staked applications in the pool have been removed to prevent conflicts in between apps with a huge stake and a small stake (25k pokt vs 2.5k pokt).
- [x] Backend has workers re-enabled and re-deployed.

Once all of this is done, this PR can be merged.